### PR TITLE
Remove close of non-existing file

### DIFF
--- a/bin/lhapdf-getdata
+++ b/bin/lhapdf-getdata
@@ -63,7 +63,6 @@ def getPDFSetFile(baseurl, filename, outdir, download=True):
             return True
         except IOError:
             logging.error("Problem while writing PDF set to '%s'" % outpath)
-            out.close()
         except:
             logging.error("Problem downloading PDF set from '%s'" % url)
         return False


### PR DESCRIPTION
`out` is never defined, so python doesn't know what to do. Removing the offending line trivially fixes this. Not entirely sure why this wasn't a problem up to now.

This could be a sign that something else was supposed to be cleaned, but I can't figure out what.